### PR TITLE
Sorts the ready panel further

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -147,6 +147,9 @@
 /proc/cmp_pdajob_asc(datum/computer_file/program/messenger/A, datum/computer_file/program/messenger/B)
 	return sorttext(B?.computer?.saved_job, A?.computer?.saved_job)
 
+/proc/cmp_jobestimate_asc(list/A, list/B) // TODO: Move this to a modular file.
+	return B["estimate"] - A["estimate"]
+
 /proc/cmp_num_string_asc(A, B)
 	return text2num(A) - text2num(B)
 

--- a/modular_zubbers/code/modules/mob/dead/dead.dm
+++ b/modular_zubbers/code/modules/mob/dead/dead.dm
@@ -13,6 +13,7 @@
 
 		sortTim(players, GLOBAL_PROC_REF(cmp_text_asc))
 
+	var/list/entry = list() //Assoc list for sorting - display name is the key, job value from crewmonitor is the value
 	for(var/ckey in players)
 		var/mob/dead/new_player/player = players[ckey]
 		var/datum/preferences/prefs = player.client?.prefs
@@ -37,15 +38,17 @@
 			else
 				display = prefs.read_preference(/datum/preference/name/real_name)
 
-		var/title = J.title
 		if(player.ready == PLAYER_READY_TO_PLAY && J.title != JOB_ASSISTANT||JOB_PRISONER)
-			if(J.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND | DEPARTMENT_BITFLAG_SILICON)
-				player_ready_data.Insert(1, "[display] as [title]")
-			else
-				player_ready_data += "* [display] as [title]"
+			entry[display] = list(GLOB.crewmonitor.jobs[J.title], J.title)
+
+	entry = sort_list(entry, GLOBAL_PROC_REF(cmp_numeric_asc)) // Sort list by job ID.
+
+	for(var/character_name in entry)
+		var/job_title = entry[character_name][2]
+		player_ready_data += "* [character_name] as [job_title]"
 
 	if(length(player_ready_data))
-		player_ready_data.Insert(1, "------------------")
-		player_ready_data.Insert(1, "Job Estimation:")
 		player_ready_data.Insert(1, "")
+		player_ready_data.Insert(2, "Job Estimation:")
+		player_ready_data.Insert(3, "------------------")
 	return player_ready_data


### PR DESCRIPTION
Uses the sorted list from the crewmonitor to sort the estimation list.

Unsure if it works, and not sure how it interacts with silicons, as those aren't on the crew monitor's list.
